### PR TITLE
Add scraped page archive

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -55,4 +55,4 @@ def scrape_list(url)
   end
 end
 
-scrape_list('http://www.haiti-reference.com/politique/legislatif/49eme_legis.php')
+scrape_list('https://www.haiti-reference.com/politique/legislatif/49eme_legis.php')

--- a/scraper.rb
+++ b/scraper.rb
@@ -8,8 +8,9 @@ require 'open-uri'
 require 'colorize'
 
 require 'pry'
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 class String
   def tidy


### PR DESCRIPTION
Adds scraped page archive.

# Scraper change checklist

* [ ] ~~scraper is on Morph.io under the "everypolitician-scrapers" group~~
* [x] scraper's GitHub "Website" link points at morph.io page
* [ ] scraper is set to auto-run
@tmtmtmtm This needs to be set on Morph
* [x] scraper is archiving

# Scraped page archive

* [x] scraper uses scraped archive gem (unless upstream source has its own archive)
* [ ] morph is configured to write to GitHub ("secret" environment vars)
@tmtmtmtm The scraper's ENV variables need configuring on Morph.
* [x] pages are archived in new branch of correct scraper repo (yay!)
